### PR TITLE
modified Device::Modbus::TCP in socket creation phase

### DIFF
--- a/lib/Device/Modbus/TCP.pm
+++ b/lib/Device/Modbus/TCP.pm
@@ -20,7 +20,13 @@ sub read_port {
 
     return unless $bytes;
 
-    my $sock = $self->socket;
+    my $sock;
+    my $socket_ok=0;
+    try{
+        $sock = $self->socket;
+    }
+    return unless $socket_ok;
+
     croak "Disconnected" unless $sock->connected;
 
     local $SIG{'ALRM'} = sub { croak "Connection timed out\n" };


### PR DESCRIPTION
not fully tested; not sure this is the best way to return if a socket could not be opened; just a proposal ;-)

modified Device::Modbus::TCP to return silently unless socket was created succesfully. Prevents caller from dying.
